### PR TITLE
get rid of 'deprecated conversion from string constant to char*' warning

### DIFF
--- a/src/SPIFFSIniFile.cpp
+++ b/src/SPIFFSIniFile.cpp
@@ -4,7 +4,7 @@
 
 const uint8_t SPIFFSIniFile::maxFilenameLen = SPIFFSINI_FILE_MAX_FILENAME_LEN;
 
-SPIFFSIniFile::SPIFFSIniFile(const char* filename, char* mode,
+SPIFFSIniFile::SPIFFSIniFile(const char* filename, const char* mode,
 				 bool caseSensitive)
 {
 	if (strlen(filename) <= maxFilenameLen)

--- a/src/SPIFFSIniFile.h
+++ b/src/SPIFFSIniFile.h
@@ -28,7 +28,7 @@ public:
 	static const uint8_t maxFilenameLen;
 
 	// Create an SPIFFSIniFile object. It isn't opened until open() is called on it.
-	SPIFFSIniFile(const char* filename, char* mode = "r",
+	SPIFFSIniFile(const char* filename, const char* mode = "r",
 			bool caseSensitive = false);
 	~SPIFFSIniFile();
 
@@ -40,7 +40,7 @@ public:
 	inline error_t getError(void) const;
 	inline void clearError(void) const;
 	// Get the file mode (FILE_READ/FILE_WRITE)
-	inline char* getMode(void) const;
+	inline const char* getMode(void) const;
 
 	// Get the filename asscoiated with the ini file object
 	inline const char* getFilename(void) const;
@@ -117,7 +117,7 @@ protected:
 
 private:
 	char _filename[SPIFFSINI_FILE_MAX_FILENAME_LEN];
-	char* _mode;
+	const char* _mode;
 	mutable error_t _error;
 	mutable File _file;
 	bool _caseSensitive;
@@ -159,7 +159,7 @@ void SPIFFSIniFile::clearError(void) const
 	_error = errorNoError;
 }
 
-char* SPIFFSIniFile::getMode(void) const
+const char* SPIFFSIniFile::getMode(void) const
 {
 	return _mode;
 }


### PR DESCRIPTION
I kept getting compiler warnings like this:

> In file included from [...]/libraries/SPIFFSIniFile/src/SPIFFSIniFile.cpp:1:0:
> [...]/libraries/SPIFFSIniFile/src/SPIFFSIniFile.h:31:51: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
> SPIFFSIniFile(const char* filename, char* mode = "r",

And this change fixes that for me. (But I'm not an expert in C++ and not sure if this is the proper way to do it).